### PR TITLE
Add support for octal integer literals

### DIFF
--- a/syntax/yara.vim
+++ b/syntax/yara.vim
@@ -56,7 +56,7 @@ syntax region yaraStringRegex start=/\// end=/\// skip=/\(\\\\\|\\\/\)/
 syntax match yaraStringRegexModifiers /\/\@<=[is]\+\>/
 
 " Numbers
-syntax match yaraNumberInt /\<\([0-9]\+\|0x[0-9a-fA-F]\+\)\>/
+syntax match yaraNumberInt /\<\([0-9]\+\|0x[0-9a-fA-F]\+\|0o[0-7]\+\)\>/
 syntax match yaraNumberFloat /\<[0-9]\+\.[0-9]\+\>/
 syntax match yaraNumberSize /\<\([0-9]\+\|0x[0-9a-fA-F]\+\)\(MB\|KB\)\>/
 


### PR DESCRIPTION
Hi s3rvac and thanks, I am a long time user of this syntax highlighting :)

Even though I was not able to find this mentioned in the documentation. They have it defined in the lexer explicitly: https://github.com/VirusTotal/yara/blob/2f96c5ab22aeb2f7c3a450a3c5df6ae96e7aa672/libyara/lexer.l#L562

Current syntax highlighting:
![yara_syntax_old](https://user-images.githubusercontent.com/26434056/185569967-c75885fc-afa7-4a2d-b993-3b560c7367c3.png)

New syntax highlighting:
![yara_syntax_good](https://user-images.githubusercontent.com/26434056/185569985-163d3326-8e67-494e-b868-1de8382972c1.png)

We have already started to add/support this in our projects:
- yaramod PR :: https://github.com/avast/yaramod/pull/219
- yls PR :: https://github.com/avast/yls/pull/4

An example:
```fish
/tmp (⎈ play-ns|playground)
λ cat test.yar
   1 rule test {
   2     condition:
   3         12 and 0x12 and 0o12
   4 }

/tmp (⎈ play-ns|playground)
λ yarac test.yar /dev/null

/tmp (⎈ play-ns|playground)
λ echo $status
0
```
