### PR TITLE
Improve syntax for comments inside hex strings

### DIFF
--- a/syntax/yara.vim
+++ b/syntax/yara.vim
@@ -50,7 +50,7 @@ syntax match yaraIdentifierMatchLength /![a-zA-Z0-9_]*\(\[[^\]]\+\]\)\?/
 " Strings
 syntax region yaraStringText start=/"/ end=/"/ skip=/\(\\\\\|\\"\)/ contains=yaraStringTextFormat
 syntax match yaraStringTextFormat /\(\\"\|\\\\\|\\t\|\\r\|\\n\|\\x[0-9a-fA-F]\{2\}\)/ contained
-syntax match yaraStringHex /{\([-0-9a-fA-F \t()\[\]|?]\|\n\)\+[-0-9a-fA-F()\[\]|?]\([-0-9a-fA-F \t()\[\]|?]\|\n\)\+}/ contains=yaraStringHexFormat
+syntax match yaraStringHex /{\(\_s*\|[-0-9a-fA-F()\[\]|?]\|\/\/.*\_$\|\/\*\_.\{-}\*\/\)\+}/ contains=yaraStringHexFormat,yaraCommentInline,yaraCommentBlock
 syntax match yaraStringHexFormat /[-()\[\]|?]/ contained
 syntax region yaraStringRegex start=/\// end=/\// skip=/\(\\\\\|\\\/\)/
 syntax match yaraStringRegexModifiers /\/\@<=[is]\+\>/


### PR DESCRIPTION
Before and after the change:

![before](https://github.com/s3rvac/vim-syntax-yara/assets/447065/778ea410-f60e-4865-ac61-138b14fe2eb6)

![after](https://github.com/s3rvac/vim-syntax-yara/assets/447065/e79543e5-1701-4c64-b5e2-fde9e3c35c37)